### PR TITLE
Fixes for Id format and disabled devices

### DIFF
--- a/wb-homeassistant.js
+++ b/wb-homeassistant.js
@@ -140,8 +140,13 @@ function registerSerialDevices() {
             if (device.device_type.lastIndexOf('WB-', 0) === 0) {
                 deviceInfo['manufacturer'] = 'Wiren Board';
             }
-            var deviceId = "{}_{}".format(device.device_type, device.slave_id).toLowerCase();
-            registerDevice(deviceId, deviceInfo);
+            var deviceId = "{}_{}".format(device.device_type, device.slave_id).toLowerCase().replace('.', '').replace(' ', '-');
+            if (device.enabled) {
+                registerDevice(deviceId, deviceInfo);
+            }
+            else {
+                log("Device {} is disabled, skipping registration for Home Assistant auto discovery", deviceId);
+            }
         });
     });
 }


### PR DESCRIPTION
In both cases, when Id has invalid caracters or device is disabled, getDevice() throwed an error.